### PR TITLE
fix: typo in cli.py

### DIFF
--- a/src/kicad_auto_silkscreen/cli.py
+++ b/src/kicad_auto_silkscreen/cli.py
@@ -16,7 +16,7 @@ class DynamicSilkscreenCommand(click.Command):
 
             # Handle boolean flags
             if field_type == bool:
-                option = click.Option(param_decls=[option_name], is_flag=True, default=dault_value)
+                option = click.Option(param_decls=[option_name], is_flag=True, default=default_value)
             else:
                 # For other types, use the appropriate click type (str, int, float, etc.)
                 option = click.Option(param_decls=[option_name], default=default_value, type=field_type)


### PR DESCRIPTION
Fixes NameError

```
Traceback (most recent call last):
  File "/var/data/python/bin/kicad_auto_silkscreen", line 5, in <module>
    from kicad_auto_silkscreen.cli import main
  File "/var/data/python/lib/python3.13/site-packages/kicad_auto_silkscreen/cli.py", line 28, in <module>
    @click.command(cls=DynamicSilkscreenCommand)
     ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/data/python/lib/python3.13/site-packages/click/decorators.py", line 248, in decorator
    cmd = cls(name=cmd_name, callback=f, params=params, **attrs)
  File "/var/data/python/lib/python3.13/site-packages/kicad_auto_silkscreen/cli.py", line 19, in __init__
    option = click.Option(param_decls=[option_name], is_flag=True, default=dault_value)
                                                                           ^^^^^^^^^^^
NameError: name 'dault_value' is not defined. Did you mean: 'default_value'?
```